### PR TITLE
ch.8 상속 (#11)

### DIFF
--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F860989B2876AE4F00449CAA /* XYPoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XYPoint.h; sourceTree = "<group>"; };
 		F86ADE0E2871D5580047783B /* Objective-C-ch8 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Objective-C-ch8"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F86ADE112871D5580047783B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F86ADE192871E63A0047783B /* Rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rectangle.h; sourceTree = "<group>"; };
@@ -44,6 +45,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F860989A2876AE3000449CAA /* XYPoint */ = {
+			isa = PBXGroup;
+			children = (
+				F860989B2876AE4F00449CAA /* XYPoint.h */,
+			);
+			path = XYPoint;
+			sourceTree = "<group>";
+		};
 		F86ADE052871D5580047783B = {
 			isa = PBXGroup;
 			children = (
@@ -63,6 +72,7 @@
 		F86ADE102871D5580047783B /* Objective-C-ch8 */ = {
 			isa = PBXGroup;
 			children = (
+				F860989A2876AE3000449CAA /* XYPoint */,
 				F86ADE112871D5580047783B /* main.m */,
 				F86ADE1E2871E9980047783B /* Square */,
 				F86ADE182871E62F0047783B /* Rectangle */,

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		F86ADE122871D5580047783B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE112871D5580047783B /* main.m */; };
+		F86ADE1B2871E6AC0047783B /* Rectangle.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE1A2871E6AC0047783B /* Rectangle.m */; };
+		F86ADE212871E9FA0047783B /* Square.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE202871E9FA0047783B /* Square.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,6 +27,10 @@
 /* Begin PBXFileReference section */
 		F86ADE0E2871D5580047783B /* Objective-C-ch8 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Objective-C-ch8"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F86ADE112871D5580047783B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F86ADE192871E63A0047783B /* Rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rectangle.h; sourceTree = "<group>"; };
+		F86ADE1A2871E6AC0047783B /* Rectangle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Rectangle.m; sourceTree = "<group>"; };
+		F86ADE1F2871E9AA0047783B /* Square.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Square.h; sourceTree = "<group>"; };
+		F86ADE202871E9FA0047783B /* Square.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Square.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,8 +64,28 @@
 			isa = PBXGroup;
 			children = (
 				F86ADE112871D5580047783B /* main.m */,
+				F86ADE1E2871E9980047783B /* Square */,
+				F86ADE182871E62F0047783B /* Rectangle */,
 			);
 			path = "Objective-C-ch8";
+			sourceTree = "<group>";
+		};
+		F86ADE182871E62F0047783B /* Rectangle */ = {
+			isa = PBXGroup;
+			children = (
+				F86ADE192871E63A0047783B /* Rectangle.h */,
+				F86ADE1A2871E6AC0047783B /* Rectangle.m */,
+			);
+			path = Rectangle;
+			sourceTree = "<group>";
+		};
+		F86ADE1E2871E9980047783B /* Square */ = {
+			isa = PBXGroup;
+			children = (
+				F86ADE1F2871E9AA0047783B /* Square.h */,
+				F86ADE202871E9FA0047783B /* Square.m */,
+			);
+			path = Square;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -119,7 +145,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F86ADE212871E9FA0047783B /* Square.m in Sources */,
 				F86ADE122871D5580047783B /* main.m in Sources */,
+				F86ADE1B2871E6AC0047783B /* Rectangle.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		F86ADE122871D5580047783B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE112871D5580047783B /* main.m */; };
 		F86ADE1B2871E6AC0047783B /* Rectangle.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE1A2871E6AC0047783B /* Rectangle.m */; };
 		F86ADE212871E9FA0047783B /* Square.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE202871E9FA0047783B /* Square.m */; };
+		F89E8F222878774E0093CE55 /* XYPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = F89E8F212878774E0093CE55 /* XYPoint.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,6 +33,7 @@
 		F86ADE1A2871E6AC0047783B /* Rectangle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Rectangle.m; sourceTree = "<group>"; };
 		F86ADE1F2871E9AA0047783B /* Square.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Square.h; sourceTree = "<group>"; };
 		F86ADE202871E9FA0047783B /* Square.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Square.m; sourceTree = "<group>"; };
+		F89E8F212878774E0093CE55 /* XYPoint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XYPoint.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,6 +51,7 @@
 			isa = PBXGroup;
 			children = (
 				F860989B2876AE4F00449CAA /* XYPoint.h */,
+				F89E8F212878774E0093CE55 /* XYPoint.m */,
 			);
 			path = XYPoint;
 			sourceTree = "<group>";
@@ -158,6 +161,7 @@
 				F86ADE212871E9FA0047783B /* Square.m in Sources */,
 				F86ADE122871D5580047783B /* main.m in Sources */,
 				F86ADE1B2871E6AC0047783B /* Rectangle.m in Sources */,
+				F89E8F222878774E0093CE55 /* XYPoint.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.pbxproj
@@ -1,0 +1,282 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F86ADE122871D5580047783B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F86ADE112871D5580047783B /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F86ADE0C2871D5580047783B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		F86ADE0E2871D5580047783B /* Objective-C-ch8 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Objective-C-ch8"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F86ADE112871D5580047783B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F86ADE0B2871D5580047783B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F86ADE052871D5580047783B = {
+			isa = PBXGroup;
+			children = (
+				F86ADE102871D5580047783B /* Objective-C-ch8 */,
+				F86ADE0F2871D5580047783B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F86ADE0F2871D5580047783B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F86ADE0E2871D5580047783B /* Objective-C-ch8 */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F86ADE102871D5580047783B /* Objective-C-ch8 */ = {
+			isa = PBXGroup;
+			children = (
+				F86ADE112871D5580047783B /* main.m */,
+			);
+			path = "Objective-C-ch8";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F86ADE0D2871D5580047783B /* Objective-C-ch8 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F86ADE152871D5580047783B /* Build configuration list for PBXNativeTarget "Objective-C-ch8" */;
+			buildPhases = (
+				F86ADE0A2871D5580047783B /* Sources */,
+				F86ADE0B2871D5580047783B /* Frameworks */,
+				F86ADE0C2871D5580047783B /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Objective-C-ch8";
+			productName = "Objective-C-ch8";
+			productReference = F86ADE0E2871D5580047783B /* Objective-C-ch8 */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F86ADE062871D5580047783B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					F86ADE0D2871D5580047783B = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+				};
+			};
+			buildConfigurationList = F86ADE092871D5580047783B /* Build configuration list for PBXProject "Objective-C-ch8" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F86ADE052871D5580047783B;
+			productRefGroup = F86ADE0F2871D5580047783B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F86ADE0D2871D5580047783B /* Objective-C-ch8 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F86ADE0A2871D5580047783B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F86ADE122871D5580047783B /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F86ADE132871D5580047783B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		F86ADE142871D5580047783B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		F86ADE162871D5580047783B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		F86ADE172871D5580047783B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F86ADE092871D5580047783B /* Build configuration list for PBXProject "Objective-C-ch8" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F86ADE132871D5580047783B /* Debug */,
+				F86ADE142871D5580047783B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F86ADE152871D5580047783B /* Build configuration list for PBXNativeTarget "Objective-C-ch8" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F86ADE162871D5580047783B /* Debug */,
+				F86ADE172871D5580047783B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F86ADE062871D5580047783B /* Project object */;
+}

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
@@ -6,10 +6,17 @@
 //
 
 #import <Foundation/Foundation.h>
+//#import "../XYPoint/XYPoint.h"
+
+// import 와 동일하게 컴파일러에게 무슨 클래스인지 알려준다.
+@class XYPoint;
 
 @interface Rectangle: NSObject
 
 @property int width, height;
+
+- (XYPoint *)origin;
+- (void)setOrigin:(XYPoint *)pt;
 - (int)area;
 - (int)perimeter;
 - (void)setWidth:(int)w andHeight:(int)h;

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
@@ -1,0 +1,16 @@
+//
+//  Rectangle.h
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/03.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Rectangle: NSObject
+
+@property int width, height;
+- (int)area;
+- (int)perimeter;
+- (void)setWidth:(int)w andHeight:(int)h;
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.h
@@ -6,10 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
-//#import "../XYPoint/XYPoint.h"
+// @class가 제공하는 정보보다 많은 정보가 필요하기 때문에.
+#import "../XYPoint/XYPoint.h"
 
 // import 와 동일하게 컴파일러에게 무슨 클래스인지 알려준다.
-@class XYPoint;
+//@class XYPoint;
 
 @interface Rectangle: NSObject
 

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
@@ -25,7 +25,12 @@
 }
 
 - (XYPoint *)origin {
-    return origin;
+    // 객체의 사본을 만들어서 반환.
+    XYPoint *theOrigin = [[XYPoint alloc] init];
+    theOrigin.x = origin.x;
+    theOrigin.y = origin.y;
+    
+    return theOrigin;
 }
 
 - (void)setWidth:(int)w andHeight:(int)h {

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
@@ -1,0 +1,25 @@
+//
+//  Rectangle.m
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/04.
+//
+
+#import "Rectangle.h"
+
+@implementation Rectangle
+
+@synthesize width, height;
+- (void)setWidth:(int)w andHeight:(int)h {
+    width = w;
+    height = h;
+}
+
+- (int)area {
+    return width * height;
+}
+
+- (int)perimeter {
+    return (width + height) * 2;
+}
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
@@ -7,9 +7,21 @@
 
 #import "Rectangle.h"
 
-@implementation Rectangle
+@implementation Rectangle {
+    // 우선, setter, getter 를 만들어 보겠다.
+    XYPoint *origin;
+}
 
 @synthesize width, height;
+
+- (void)setOrigin:(XYPoint *)pt {
+    origin = pt;
+}
+
+- (XYPoint *)origin {
+    return origin;
+}
+
 - (void)setWidth:(int)w andHeight:(int)h {
     width = w;
     height = h;

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Rectangle/Rectangle.m
@@ -15,7 +15,13 @@
 @synthesize width, height;
 
 - (void)setOrigin:(XYPoint *)pt {
-    origin = pt;
+    // 각 Rectangle 인스턴스가 자신만의 origin 을 소유할 수 있도록 하기 위함.
+    // origin 메서드를 자동 생성하지 않은 이유가 이것이다. 기본적으로, 자동 생성된 세터는 객체 자체를 복사하지 않고, 객체의 포인터만 복사한다.
+    if (!origin)
+        // 0 이 아니면,
+        origin = [[XYPoint alloc] init];
+    origin.x = pt.x;
+    origin.y = pt.y;
 }
 
 - (XYPoint *)origin {

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Square/Square.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Square/Square.h
@@ -1,0 +1,13 @@
+//
+//  Square.h
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/04.
+//
+
+#import "../Rectangle/Rectangle.h"
+
+@interface Square: Rectangle
+- (void)setSide:(int)s;
+- (int)side;
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/Square/Square.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/Square/Square.m
@@ -1,0 +1,20 @@
+//
+//  Square.m
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/04.
+//
+
+#import "Square.h"
+
+@implementation Square: Rectangle
+
+- (void)setSide:(int)s {
+    [self setWidth:s andHeight:s];
+}
+
+- (int)side {
+    return self.width;
+}
+
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.h
@@ -1,0 +1,15 @@
+//
+//  XYPoint.h
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/07.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface XYPoint : NSObject
+
+@property int x, y;
+
+- (void)setX:(int)xVal andY:(int)yVal;
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.h
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.h
@@ -5,9 +5,9 @@
 //  Created by kimhyungyu on 2022/07/07.
 //
 
-#import <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 
-@interface XYPoint : NSObject
+@interface XYPoint: NSObject
 
 @property int x, y;
 

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/XYPoint/XYPoint.m
@@ -1,0 +1,18 @@
+//
+//  XYPoint.m
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/08.
+//
+
+#import "XYPoint.h"
+
+@implementation XYPoint
+
+//@synthesize x, y;
+- (void)setX:(int)xVal andY:(int)yVal {
+    self.x = xVal;
+    self.y = yVal;
+}
+
+@end

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  Objective-C-ch8
+//
+//  Created by kimhyungyu on 2022/07/03.
+//
+
+#import <Foundation/Foundation.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // insert code here...
+        NSLog(@"Hello, World!");
+    }
+    return 0;
+}

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -8,14 +8,23 @@
 
 #import "Rectangle.h"
 #import "Square.h"
+#import "XYPoint.h"
 
 int main(int argc, const char * argv[]) {
     @autoreleasepool {
         Rectangle *myRect = [[Rectangle alloc] init];
+        XYPoint *myPoint = [[XYPoint alloc] init];
+        
+        [myPoint setX:100 andY:200];
         
         [myRect setWidth:5 andHeight:8];
+        myRect.origin = myPoint;
+//        다음의 표현식을 사용하는 것과 동일하다. origin 을 @property 로 선언하지 않아도 setOrigin 메서드가 있다면 위와 같은 표현식도 가능하다.
+//        [myRect setOrigin:myPoint]
+        
         
         NSLog(@"Rectangle: w = %i, h = %i", myRect.width, myRect.height);
+        NSLog(@"Origin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
         NSLog(@"Area: %i, Permineter = %i", [myRect area], [myRect perimeter]);
         
         Square *mySquare = [[Square alloc] init];

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -27,6 +27,10 @@ int main(int argc, const char * argv[]) {
         NSLog(@"Origin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
         NSLog(@"Area: %i, Permineter = %i", [myRect area], [myRect perimeter]);
         
+        [myPoint setX:50 andY:50];
+        
+        NSLog(@"Origin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
+        
         Square *mySquare = [[Square alloc] init];
         
         [mySquare setSide:5];

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -7,10 +7,48 @@
 
 #import <Foundation/Foundation.h>
 
+//MARK: - Class A
+
+@interface ClassA : NSObject {
+    int x;
+}
+
+- (void)initVar;
+
+@end
+
+@implementation ClassA
+
+- (void)initVar {
+    x = 100;
+}
+
+@end
+
+//MARK: - Class B
+
+@interface ClassB : ClassA
+
+- (void)printVar;
+
+@end
+
+@implementation ClassB
+
+- (void)printVar {
+    NSLog(@"x = %i", x);
+}
+
+@end
+
+//MARK: - main
+
 int main(int argc, const char * argv[]) {
     @autoreleasepool {
-        // insert code here...
-        NSLog(@"Hello, World!");
+        ClassB *b = [[ClassB alloc] init];
+        
+        [b initVar];
+        [b printVar];
     }
     return 0;
 }

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -22,7 +22,6 @@ int main(int argc, const char * argv[]) {
 //        다음의 표현식을 사용하는 것과 동일하다. origin 을 @property 로 선언하지 않아도 setOrigin 메서드가 있다면 위와 같은 표현식도 가능하다.
 //        [myRect setOrigin:myPoint]
         
-        
         NSLog(@"Rectangle: w = %i, h = %i", myRect.width, myRect.height);
         NSLog(@"Origin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
         NSLog(@"Area: %i, Permineter = %i", [myRect area], [myRect perimeter]);
@@ -30,6 +29,14 @@ int main(int argc, const char * argv[]) {
         [myPoint setX:50 andY:50];
         
         NSLog(@"Origin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
+        
+        XYPoint *theOrigin = myRect.origin;
+        theOrigin.x = 200;
+        theOrigin.y = 300;
+        
+        // setter 와 마찬가지로 getter 역시 누구든 theOrigin 의 원점 객체를 바꾸면 myRect 의 값도 바뀌는 것을 볼 수 있다.
+        // origin getter 메서드를 수정해보자.
+        NSLog(@"theOrigin: at (%i, %i)", myRect.origin.x, myRect.origin.y);
         
         Square *mySquare = [[Square alloc] init];
         

--- a/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
+++ b/ch8-상속/Objective-C-ch8/Objective-C-ch8/main.m
@@ -5,6 +5,30 @@
 //  Created by kimhyungyu on 2022/07/03.
 //
 
+
+#import "Rectangle.h"
+#import "Square.h"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        Rectangle *myRect = [[Rectangle alloc] init];
+        
+        [myRect setWidth:5 andHeight:8];
+        
+        NSLog(@"Rectangle: w = %i, h = %i", myRect.width, myRect.height);
+        NSLog(@"Area: %i, Permineter = %i", [myRect area], [myRect perimeter]);
+        
+        Square *mySquare = [[Square alloc] init];
+        
+        [mySquare setSide:5];
+        
+        NSLog(@"Square s = %i", [mySquare side]);
+        NSLog(@"Area = %i, Perimeter = %i", [mySquare area], [mySquare perimeter]);
+    }
+    return 0;
+}
+
+/*
 #import <Foundation/Foundation.h>
 
 //MARK: - Class A
@@ -52,3 +76,4 @@ int main(int argc, const char * argv[]) {
     }
     return 0;
 }
+*/


### PR DESCRIPTION
- 인스턴스 변수와 메서드 상속 받기
- @class 지시어 사용해서 컴파일러에게 클래스의 정보 알리기
- @implementation 에서 클래슬를 사용하기 위해서는 import 로 헤더파일을 추가해줘야 한다.

> - `@property` 로 선언하지 않아도 setter, getter 메서드를 만들어 뒀다면 연산자처럼 이용 가능하다.
> - `.`연산자는 프로퍼티에 사용하도록 만들어졌고, 작업은 디괄호를 사용한 메세지 표현식을 쓰는 것이 바람직하다.

close #11